### PR TITLE
Add settings screen with accessibility toggles

### DIFF
--- a/context/AppContext.js
+++ b/context/AppContext.js
@@ -5,9 +5,25 @@ const AppContext = createContext();
 export function AppProvider({ children }) {
   const [age, setAge] = useState(null);
   const [selectedEmotions, setSelectedEmotions] = useState([]);
+  const [highContrast, setHighContrast] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const [textSize, setTextSize] = useState(16);
 
   return (
-    <AppContext.Provider value={{ age, setAge, selectedEmotions, setSelectedEmotions }}>
+    <AppContext.Provider
+      value={{
+        age,
+        setAge,
+        selectedEmotions,
+        setSelectedEmotions,
+        highContrast,
+        setHighContrast,
+        reduceMotion,
+        setReduceMotion,
+        textSize,
+        setTextSize,
+      }}
+    >
       {children}
     </AppContext.Provider>
   );

--- a/navigation.js
+++ b/navigation.js
@@ -4,6 +4,7 @@ import SplashScreen from './screens/SplashScreen';
 import HomeScreen from './screens/HomeScreen';
 import EmotionDetailScreen from './screens/EmotionDetailScreen';
 import SoupScreen from './screens/SoupScreen';
+import SettingsScreen from './screens/SettingsScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -14,6 +15,7 @@ export default function Navigation() {
       <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'Emotion Soup' }} />
       <Stack.Screen name="EmotionDetail" component={EmotionDetailScreen} options={{ title: 'Feeling' }} />
       <Stack.Screen name="Soup" component={SoupScreen} options={{ title: 'Your Soup' }} />
+      <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: 'Settings' }} />
     </Stack.Navigator>
   );
 }

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, Button } from 'react-native';
 import PuffBall from '../components/PuffBall';
 import { useApp } from '../context/AppContext';
 
@@ -22,7 +22,10 @@ export default function HomeScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>How are you feeling?</Text>
+      <View style={styles.header}>
+        <Text style={styles.title}>How are you feeling?</Text>
+        <Button title="Settings" onPress={() => navigation.navigate('Settings')} />
+      </View>
       <FlatList
         data={EMOTIONS}
         numColumns={3}
@@ -40,6 +43,7 @@ export default function HomeScreen({ navigation }) {
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', paddingTop: 40 },
-  title: { fontSize: 20, marginBottom: 20 },
+  header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', width: '90%', marginBottom: 20 },
+  title: { fontSize: 20 },
   item: { alignItems: 'center', margin: 10 },
 });

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Text, StyleSheet, Switch } from 'react-native';
+import Slider from '@react-native-community/slider';
+import { useApp } from '../context/AppContext';
+
+export default function SettingsScreen() {
+  const {
+    highContrast,
+    setHighContrast,
+    reduceMotion,
+    setReduceMotion,
+    textSize,
+    setTextSize,
+  } = useApp();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Accessibility</Text>
+
+      <View style={styles.row}>
+        <Text style={styles.label}>High Contrast Mode</Text>
+        <Switch value={highContrast} onValueChange={setHighContrast} />
+      </View>
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Reduce Motion</Text>
+        <Switch value={reduceMotion} onValueChange={setReduceMotion} />
+      </View>
+
+      <Text style={styles.label}>Text Size: {textSize}</Text>
+      <Slider
+        style={{ width: '100%' }}
+        minimumValue={14}
+        maximumValue={24}
+        step={1}
+        value={textSize}
+        onValueChange={setTextSize}
+      />
+      <Text style={{ fontSize: textSize, marginTop: 20 }}>Preview text</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 },
+  title: { fontSize: 24, marginBottom: 20 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginVertical: 10,
+  },
+  label: { fontSize: 16 },
+});


### PR DESCRIPTION
## Summary
- add `SettingsScreen` for accessibility options
- store accessibility preferences in context
- integrate settings screen in navigation
- provide button on home screen to open settings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68426271e44c8320ad24022b63bf4178