### PR TITLE
Implement premium tier logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ This project is a React Native application built with Expo. It helps children ex
 - `firebase.js` Firebase initialization (configure with your own keys)
 
 This skeleton includes basic navigation and placeholder screens for future development.
+
+## User Tiers
+
+Authentication is handled with Firebase Auth. Each user also has a document in the `users` collection of Firestore:
+
+```json
+{
+  "email": "user@example.com",
+  "tier": "free" // or "premium"
+}
+```
+
+The `hooks/useUserTier.js` hook reads this value so the app can show premium features, such as emotion stories. Until in-app payments are integrated you can manually set `tier: "premium"` on your user document in Firestore for testing.

--- a/hooks/useUserTier.js
+++ b/hooks/useUserTier.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { auth, db } from '../firebase';
+import { doc, getDoc } from 'firebase/firestore';
+
+export default function useUserTier() {
+  const [tier, setTier] = useState('free');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+
+    const fetchTier = async () => {
+      const docRef = doc(db, 'users', uid);
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        setTier(docSnap.data().tier || 'free');
+      }
+      setLoading(false);
+    };
+
+    fetchTier();
+  }, []);
+
+  return { tier, loading };
+}

--- a/screens/EmotionDetailScreen.js
+++ b/screens/EmotionDetailScreen.js
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Button } from 'react-native';
+import { View, Text, StyleSheet, Button, ActivityIndicator } from 'react-native';
 import EmotionSliders from '../components/EmotionSliders';
 import { useApp } from '../context/AppContext';
+import EmotionStoryBox from '../components/EmotionStoryBox';
+import useUserTier from '../hooks/useUserTier';
 
 export default function EmotionDetailScreen({ route, navigation }) {
   const { emotion } = route.params;
   const { selectedEmotions, setSelectedEmotions } = useApp();
   const [size, setSize] = useState(50);
   const [temperature, setTemperature] = useState(0);
+  const { tier, loading } = useUserTier();
 
   const addToSoup = () => {
     const newEmotion = { ...emotion, size, temperature };
@@ -25,6 +28,15 @@ export default function EmotionDetailScreen({ route, navigation }) {
         setTempValue={setTemperature}
       />
       <Button title="Add to Soup" onPress={addToSoup} />
+      {loading ? (
+        <ActivityIndicator style={{ marginTop: 12 }} />
+      ) : tier === 'premium' ? (
+        <EmotionStoryBox emotion={emotion.id} size={size} temp={temperature} />
+      ) : (
+        <Text style={{ textAlign: 'center', marginTop: 12 }}>
+          Upgrade to Premium to see a custom story!
+        </Text>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add `useUserTier` hook to load role from Firestore
- show emotion story only for premium tier users
- document user tier structure and manual setup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684277ade5908320a9d810196ebf997e