### PR TITLE
Add animated EmotionPuffBall to screens

### DIFF
--- a/components/EmotionPuffBall.js
+++ b/components/EmotionPuffBall.js
@@ -1,6 +1,15 @@
 import React, { useRef, useEffect } from 'react';
 import { Text, TouchableWithoutFeedback, Animated, StyleSheet, Vibration } from 'react-native';
 
+const emojiMap = {
+  anger: '😡',
+  sadness: '😢',
+  happiness: '😊',
+  joy: '😊',
+  fear: '😱',
+  love: '😍',
+};
+
 export default function EmotionPuffBall({ emotion, color, size = 100, onPress }) {
   const scaleAnim = useRef(new Animated.Value(1)).current;
   const pulseAnim = useRef(new Animated.Value(1)).current;
@@ -55,7 +64,7 @@ export default function EmotionPuffBall({ emotion, color, size = 100, onPress })
           },
         ]}
       >
-        <Text style={styles.face}>😊</Text>
+        <Text style={styles.face}>{emojiMap[emotion] || '😊'}</Text>
       </Animated.View>
     </TouchableWithoutFeedback>
   );

--- a/screens/EmotionDetailScreen.js
+++ b/screens/EmotionDetailScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Button } from 'react-native';
+import EmotionPuffBall from '../components/EmotionPuffBall';
 import EmotionSliders from '../components/EmotionSliders';
 import { useApp } from '../context/AppContext';
 
@@ -18,6 +19,11 @@ export default function EmotionDetailScreen({ route, navigation }) {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>{emotion.id}</Text>
+      <EmotionPuffBall
+        emotion={emotion.id}
+        color={emotion.color}
+        size={size}
+      />
       <EmotionSliders
         sizeValue={size}
         setSizeValue={setSize}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet, Button } from 'react-native';
-import PuffBall from '../components/PuffBall';
+import { View, Text, FlatList, StyleSheet, Button } from 'react-native';
+import EmotionPuffBall from '../components/EmotionPuffBall';
 import { useApp } from '../context/AppContext';
 
 const EMOTIONS = [
@@ -31,10 +31,14 @@ export default function HomeScreen({ navigation }) {
         numColumns={3}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <TouchableOpacity onPress={() => selectEmotion(item)} style={styles.item}>
-            <PuffBall color={item.color} />
+          <View style={styles.item}>
+            <EmotionPuffBall
+              emotion={item.id}
+              color={item.color}
+              onPress={() => selectEmotion(item)}
+            />
             <Text>{item.id}</Text>
-          </TouchableOpacity>
+          </View>
         )}
       />
     </View>

--- a/screens/SoupScreen.js
+++ b/screens/SoupScreen.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
 import { useApp } from '../context/AppContext';
-import PuffBall from '../components/PuffBall';
+import EmotionPuffBall from '../components/EmotionPuffBall';
 
 export default function SoupScreen() {
   const { selectedEmotions } = useApp();
@@ -14,8 +14,14 @@ export default function SoupScreen() {
         keyExtractor={(item, index) => item.id + index}
         renderItem={({ item }) => (
           <View style={styles.item}>
-            <PuffBall color={item.color} size={item.size} />
-            <Text>{item.id} - size {item.size} - temp {item.temperature}</Text>
+            <EmotionPuffBall
+              emotion={item.id}
+              color={item.color}
+              size={item.size}
+            />
+            <Text>
+              {item.id} - size {item.size} - temp {item.temperature}
+            </Text>
           </View>
         )}
       />


### PR DESCRIPTION
## Summary
- add emoji map to `EmotionPuffBall` for expressive faces
- show the animated puff ball on Emotion Detail screen
- use `EmotionPuffBall` on Home and Soup screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68427548013c83209d68a85b8ad17c7d