### PR TITLE
Add emotion logging hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ Authentication is handled with Firebase Auth. Each user also has a document in t
 ```
 
 The `hooks/useUserTier.js` hook reads this value so the app can show premium features, such as emotion stories. Until in-app payments are integrated you can manually set `tier: "premium"` on your user document in Firestore for testing.
+
+## Emotion Journal
+
+Each time a child interacts with an emotion, a journal entry is saved to Firestore in the `journal_entries` collection. Entries include the user's id, emotion name, size, temperature and a timestamp. The helper `hooks/useEmotionLogger.js` provides a simple `logEmotionEntry` function used by the app when adding an emotion to the soup.

--- a/hooks/useEmotionLogger.js
+++ b/hooks/useEmotionLogger.js
@@ -1,0 +1,15 @@
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { auth, db } from '../firebase';
+
+export default async function logEmotionEntry({ emotion, size, temperature }) {
+  const user = auth.currentUser;
+  if (!user) return;
+
+  await addDoc(collection(db, 'journal_entries'), {
+    userId: user.uid,
+    emotion,
+    size,
+    temperature,
+    timestamp: serverTimestamp(),
+  });
+}

--- a/screens/EmotionDetailScreen.js
+++ b/screens/EmotionDetailScreen.js
@@ -5,6 +5,7 @@ import EmotionSliders from '../components/EmotionSliders';
 import { useApp } from '../context/AppContext';
 import EmotionStoryBox from '../components/EmotionStoryBox';
 import useUserTier from '../hooks/useUserTier';
+import logEmotionEntry from '../hooks/useEmotionLogger';
 
 export default function EmotionDetailScreen({ route, navigation }) {
   const { emotion } = route.params;
@@ -13,9 +14,14 @@ export default function EmotionDetailScreen({ route, navigation }) {
   const [temperature, setTemperature] = useState(0);
   const { tier, loading } = useUserTier();
 
-  const addToSoup = () => {
+  const addToSoup = async () => {
     const newEmotion = { ...emotion, size, temperature };
     setSelectedEmotions([...selectedEmotions, newEmotion]);
+    await logEmotionEntry({
+      emotion: emotion.id,
+      size,
+      temperature,
+    });
     navigation.navigate('Soup');
   };
 


### PR DESCRIPTION
## Summary
- save each interaction in Firestore with `useEmotionLogger`
- log entry when emotion is added to soup
- document the journal feature

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684283ba5f9c8320940ae96fd25466a9