### PR TITLE
Implement Parent Dashboard and distress alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ The `hooks/useUserTier.js` hook reads this value so the app can show premium fea
 
 ## Emotion Journal
 
-Each time a child interacts with an emotion, a journal entry is saved to Firestore in the `journal_entries` collection. Entries include the user's id, emotion name, size, temperature and a timestamp. The helper `hooks/useEmotionLogger.js` provides a simple `logEmotionEntry` function used by the app when adding an emotion to the soup.
+Each time a child interacts with an emotion, a journal entry is saved to Firestore under `users/{uid}/emotions`. Entries include the emotion name, size, temperature and a timestamp. The helper `hooks/useEmotionLogger.js` provides a simple `logEmotionEntry` function used by the app when adding an emotion to the soup.

--- a/components/EmotionPuffBall.js
+++ b/components/EmotionPuffBall.js
@@ -1,7 +1,13 @@
 import React, { useRef, useEffect } from 'react';
 import { Text, TouchableWithoutFeedback, Animated, StyleSheet, Vibration } from 'react-native';
 
-export default function EmotionPuffBall({ emotion, color, size = 100, onPress }) {
+export default function EmotionPuffBall({
+  emotion,
+  color,
+  size = 100,
+  onPress,
+  onTripleTap,
+}) {
   const scaleAnim = useRef(new Animated.Value(1)).current;
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
@@ -22,7 +28,23 @@ export default function EmotionPuffBall({ emotion, color, size = 100, onPress })
     ).start();
   }, []);
 
+  const tapCount = useRef(0);
+  const lastTap = useRef(0);
+
   const handlePress = () => {
+    const now = Date.now();
+    if (now - lastTap.current < 300) {
+      tapCount.current += 1;
+    } else {
+      tapCount.current = 1;
+    }
+    lastTap.current = now;
+
+    if (tapCount.current === 3) {
+      tapCount.current = 0;
+      if (onTripleTap) onTripleTap();
+    }
+
     Vibration.vibrate(10);
     Animated.sequence([
       Animated.timing(scaleAnim, {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,44 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+exports.detectDistress = functions.firestore
+  .document('users/{userId}/emotions/{emotionId}')
+  .onCreate(async (snap, context) => {
+    const data = snap.data();
+    const userId = context.params.userId;
+    const db = admin.firestore();
+
+    const now = new Date();
+    const tenMinutesAgo = new Date(now.getTime() - 10 * 60 * 1000);
+    const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+    const recentSnap = await db
+      .collection(`users/${userId}/emotions`)
+      .where('timestamp', '>=', tenMinutesAgo)
+      .get();
+
+    const highIntensity = recentSnap.docs.filter(
+      (d) => (d.data().size || 0) > 80
+    );
+
+    const sameEmotionSnap = await db
+      .collection(`users/${userId}/emotions`)
+      .where('emotion', '==', data.emotion)
+      .where('timestamp', '>=', twentyFourHoursAgo)
+      .get();
+
+    const shouldFlag =
+      highIntensity.length >= 2 ||
+      sameEmotionSnap.size >= 3 ||
+      data.helpRequested === true;
+
+    if (shouldFlag) {
+      await db.collection(`users/${userId}/alerts`).add({
+        flagged: true,
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+        emotions: recentSnap.docs.map((d) => d.data().emotion),
+        reason: 'Detected possible distress pattern',
+      });
+    }
+  });

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "emotion-soup-functions",
+  "description": "Cloud functions for Emotion Soup",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  }
+}

--- a/hooks/useEmotionLogger.js
+++ b/hooks/useEmotionLogger.js
@@ -1,15 +1,20 @@
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '../firebase';
 
-export default async function logEmotionEntry({ emotion, size, temperature }) {
+export default async function logEmotionEntry({
+  emotion,
+  size,
+  temperature,
+  helpRequested = false,
+}) {
   const user = auth.currentUser;
   if (!user) return;
 
-  await addDoc(collection(db, 'journal_entries'), {
-    userId: user.uid,
+  await addDoc(collection(db, 'users', user.uid, 'emotions'), {
     emotion,
     size,
     temperature,
+    helpRequested,
     timestamp: serverTimestamp(),
   });
 }

--- a/navigation.js
+++ b/navigation.js
@@ -5,6 +5,7 @@ import HomeScreen from './screens/HomeScreen';
 import EmotionDetailScreen from './screens/EmotionDetailScreen';
 import SoupScreen from './screens/SoupScreen';
 import SettingsScreen from './screens/SettingsScreen';
+import ParentDashboardScreen from './screens/ParentDashboardScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -16,6 +17,7 @@ export default function Navigation() {
       <Stack.Screen name="EmotionDetail" component={EmotionDetailScreen} options={{ title: 'Feeling' }} />
       <Stack.Screen name="Soup" component={SoupScreen} options={{ title: 'Your Soup' }} />
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: 'Settings' }} />
+      <Stack.Screen name="ParentDashboard" component={ParentDashboardScreen} options={{ title: 'Parent Dashboard' }} />
     </Stack.Navigator>
   );
 }

--- a/screens/EmotionDetailScreen.js
+++ b/screens/EmotionDetailScreen.js
@@ -12,6 +12,7 @@ export default function EmotionDetailScreen({ route, navigation }) {
   const { selectedEmotions, setSelectedEmotions } = useApp();
   const [size, setSize] = useState(50);
   const [temperature, setTemperature] = useState(0);
+  const [helpRequested, setHelpRequested] = useState(false);
   const { tier, loading } = useUserTier();
 
   const addToSoup = async () => {
@@ -21,6 +22,7 @@ export default function EmotionDetailScreen({ route, navigation }) {
       emotion: emotion.id,
       size,
       temperature,
+      helpRequested,
     });
     navigation.navigate('Soup');
   };
@@ -32,6 +34,7 @@ export default function EmotionDetailScreen({ route, navigation }) {
         emotion={emotion.id}
         color={emotion.color}
         size={size}
+        onTripleTap={() => setHelpRequested(true)}
       />
       <EmotionSliders
         sizeValue={size}

--- a/screens/ParentDashboardScreen.js
+++ b/screens/ParentDashboardScreen.js
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { Text, Card, List, Divider } from 'react-native-paper';
+import { auth, db } from '../firebase';
+import {
+  collection,
+  getDocs,
+  query,
+  where,
+  orderBy,
+} from 'firebase/firestore';
+
+export default function ParentDashboardScreen() {
+  const [topEmotions, setTopEmotions] = useState([]);
+  const [trend, setTrend] = useState([]);
+  const [coping, setCoping] = useState([]);
+  const [alerts, setAlerts] = useState([]);
+
+  useEffect(() => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+
+    const fetchData = async () => {
+      // fetch emotions
+      const emoSnap = await getDocs(collection(db, 'users', uid, 'emotions'));
+      const counts = {};
+      const daily = {};
+      emoSnap.forEach((doc) => {
+        const d = doc.data();
+        counts[d.emotion] = (counts[d.emotion] || 0) + 1;
+        const date = d.timestamp?.toDate?.().toISOString().slice(0, 10);
+        if (date) daily[date] = (daily[date] || 0) + 1;
+      });
+      const sorted = Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5);
+      setTopEmotions(sorted);
+
+      const last7 = Object.entries(daily)
+        .sort((a, b) => (a[0] > b[0] ? 1 : -1))
+        .slice(-7);
+      setTrend(last7);
+
+      // coping tools summary (if exists)
+      try {
+        const copeSnap = await getDocs(collection(db, 'users', uid, 'coping_tools'));
+        const list = [];
+        copeSnap.forEach((d) => list.push(d.data()));
+        setCoping(list);
+      } catch (e) {
+        setCoping([]);
+      }
+
+      // alerts
+      const alertQuery = query(
+        collection(db, 'users', uid, 'alerts'),
+        where('flagged', '==', true),
+        orderBy('timestamp', 'desc')
+      );
+      const alertSnap = await getDocs(alertQuery);
+      const alertList = alertSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+      setAlerts(alertList);
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text variant="titleLarge" style={styles.welcome}>Welcome, Parent!</Text>
+
+      <Card style={styles.section}>
+        <Card.Title title="Top Emotions" />
+        <Card.Content>
+          {topEmotions.map(([emotion, count]) => (
+            <Text key={emotion}>{emotion}: {count}</Text>
+          ))}
+        </Card.Content>
+      </Card>
+
+      <Card style={styles.section}>
+        <Card.Title title="Past 7 Days" />
+        <Card.Content>
+          {trend.map(([date, count]) => (
+            <Text key={date}>{date}: {count}</Text>
+          ))}
+        </Card.Content>
+      </Card>
+
+      <Card style={styles.section}>
+        <Card.Title title="Coping Tools" />
+        <Card.Content>
+          {coping.length === 0 && <Text>No data</Text>}
+          {coping.map((c, idx) => (
+            <Text key={idx}>{c.tool}: {c.count}</Text>
+          ))}
+        </Card.Content>
+      </Card>
+
+      <List.Section title="Hidden Alerts">
+        {alerts.map((a) => (
+          <View key={a.id} style={styles.alertItem}>
+            <List.Item
+              title={`${a.emotions?.join(', ')}`}
+              description={`${a.reason} - ${a.timestamp?.toDate?.().toLocaleDateString()}`}
+            />
+            <Divider />
+          </View>
+        ))}
+      </List.Section>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  welcome: { marginBottom: 16 },
+  section: { marginBottom: 16 },
+  alertItem: { backgroundColor: '#fff' },
+});


### PR DESCRIPTION
## Summary
- log emotions under users/{uid}/emotions and allow help flag
- add triple-tap detection for help requests on emotion puffs
- create ParentDashboard screen to review stats and hidden alerts
- add Firebase Cloud Function for detecting distress patterns
- document updated journaling path

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684289bcdf7c8320afcaae833549b673