### PR TITLE
Add parent dashboard screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react": "18.x",
     "react-native": "0.72.x",
     "react-native-paper": "^5.0.0",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "react-native-chart-kit": "^6.14.1"
   },
   "devDependencies": {
     "@types/react": "^19.1.6",


### PR DESCRIPTION
## Summary
- display recent emotions for parents
- show 7-day emotion trend line chart
- surface flagged alerts
- install `react-native-chart-kit`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68428d5078788320a90b0ea1c15c099f