### PR TITLE
Add emotion stats helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,16 @@ The `hooks/useUserTier.js` hook reads this value so the app can show premium fea
 ## Emotion Journal
 
 Each time a child interacts with an emotion, a journal entry is saved to Firestore under `users/{uid}/emotions`. Entries include the emotion name, size, temperature and a timestamp. The helper `hooks/useEmotionLogger.js` provides a simple `logEmotionEntry` function used by the app when adding an emotion to the soup.
+
+### Fetching Emotion Stats
+
+To display trends over the last seven days you can use the helper `getEmotionStats(userId)` from `utils/getEmotionStats.js`. It queries `/users/{userId}/emotions` for the past week and groups entries by day and emotion.
+
+```js
+import { getEmotionStats } from './utils/getEmotionStats';
+
+const data = await getEmotionStats(userId);
+// [ { date: '2024-05-20', emotionCounts: { happy: 3, sad: 1 } }, ... ]
+```
+
+The returned array can be easily adapted for a line chart with the date on the x‑axis and counts per emotion on the y‑axis.

--- a/utils/getEmotionStats.js
+++ b/utils/getEmotionStats.js
@@ -1,0 +1,42 @@
+import { collection, getDocs, query, where, Timestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+
+/**
+ * Fetch emotion logs for the given user over the last 7 days and group
+ * them by day and emotion. Results are formatted for use with a line
+ * chart component where the x-axis is the date (YYYY-MM-DD) and the
+ * y-axis is the count for each emotion.
+ *
+ * @param {string} userId Firebase user id
+ * @returns {Promise<Array<{date: string, emotionCounts: Record<string, number>}>>}
+ */
+export async function getEmotionStats(userId) {
+  if (!userId) return [];
+
+  const today = new Date();
+  // Start date 6 days ago to include today (total 7 days)
+  const startDate = new Date(today);
+  startDate.setDate(today.getDate() - 6);
+
+  const q = query(
+    collection(db, 'users', userId, 'emotions'),
+    where('timestamp', '>=', Timestamp.fromDate(startDate))
+  );
+
+  const snap = await getDocs(q);
+  const grouped = {};
+
+  snap.forEach((doc) => {
+    const data = doc.data();
+    const ts = data.timestamp?.toDate?.();
+    if (!ts) return;
+    const day = ts.toISOString().slice(0, 10); // YYYY-MM-DD
+    if (!grouped[day]) grouped[day] = {};
+    const emotion = data.emotion || 'unknown';
+    grouped[day][emotion] = (grouped[day][emotion] || 0) + 1;
+  });
+
+  return Object.entries(grouped)
+    .sort(([d1], [d2]) => d1.localeCompare(d2))
+    .map(([date, counts]) => ({ date, emotionCounts: counts }));
+}


### PR DESCRIPTION
## Summary
- add `getEmotionStats` utility for grouping emotions by day
- document how to use the helper in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68428db6a2a08320aa83caa143e49097