### PR TITLE
Add premium subscription upgrade flow

### DIFF
--- a/hooks/useUserTier.js
+++ b/hooks/useUserTier.js
@@ -14,7 +14,8 @@ export default function useUserTier() {
       const docRef = doc(db, 'users', uid);
       const docSnap = await getDoc(docRef);
       if (docSnap.exists()) {
-        setTier(docSnap.data().tier || 'free');
+        const data = docSnap.data();
+        setTier(data.subscriptionTier || data.tier || 'free');
       }
       setLoading(false);
     };

--- a/navigation.js
+++ b/navigation.js
@@ -6,6 +6,7 @@ import EmotionDetailScreen from './screens/EmotionDetailScreen';
 import SoupScreen from './screens/SoupScreen';
 import SettingsScreen from './screens/SettingsScreen';
 import ParentDashboardScreen from './screens/ParentDashboardScreen';
+import SubscribeScreen from './screens/SubscribeScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -17,6 +18,7 @@ export default function Navigation() {
       <Stack.Screen name="EmotionDetail" component={EmotionDetailScreen} options={{ title: 'Feeling' }} />
       <Stack.Screen name="Soup" component={SoupScreen} options={{ title: 'Your Soup' }} />
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: 'Settings' }} />
+      <Stack.Screen name="Subscribe" component={SubscribeScreen} options={{ title: 'Subscribe' }} />
       <Stack.Screen name="ParentDashboard" component={ParentDashboardScreen} options={{ title: 'Parent Dashboard' }} />
     </Stack.Navigator>
   );

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { View, Text, FlatList, StyleSheet, Button } from 'react-native';
+import { View, Text, FlatList, StyleSheet, Button, ActivityIndicator } from 'react-native';
 import EmotionPuffBall from '../components/EmotionPuffBall';
 import Timer from '../components/Timer';
 import { useApp } from '../context/AppContext';
+import useUserTier from '../hooks/useUserTier';
 
 const EMOTIONS = [
   { id: 'anger', color: '#f87171' },
@@ -15,11 +16,24 @@ const EMOTIONS = [
 
 export default function HomeScreen({ navigation }) {
   const { setSelectedEmotions } = useApp();
+  const { tier, loading } = useUserTier();
 
   const selectEmotion = (emotion) => {
+    if ((emotion.id === 'love' || emotion.id === 'fear') && tier !== 'premium') {
+      navigation.navigate('Subscribe');
+      return;
+    }
     setSelectedEmotions([emotion]);
     navigation.navigate('EmotionDetail', { emotion });
   };
+
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator style={{ marginTop: 50 }} />
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -44,6 +58,12 @@ export default function HomeScreen({ navigation }) {
           </View>
         )}
       />
+      {tier !== 'premium' && (
+        <Button
+          title="Upgrade to Premium"
+          onPress={() => navigation.navigate('Subscribe')}
+        />
+      )}
     </View>
   );
 }

--- a/screens/SubscribeScreen.js
+++ b/screens/SubscribeScreen.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { auth, db } from '../firebase';
+import { doc, setDoc } from 'firebase/firestore';
+
+export default function SubscribeScreen() {
+  const [thanks, setThanks] = useState(false);
+
+  const upgrade = async () => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    await setDoc(
+      doc(db, 'users', uid),
+      { subscriptionTier: 'premium' },
+      { merge: true }
+    );
+    setThanks(true);
+  };
+
+  return (
+    <View style={styles.container}>
+      {thanks ? (
+        <Text style={styles.thanks}>Thank you!</Text>
+      ) : (
+        <>
+          <Text style={styles.title}>Upgrade to Premium</Text>
+          <Button title="Confirm Upgrade" onPress={upgrade} />
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 20 },
+  thanks: { fontSize: 24 },
+});


### PR DESCRIPTION
## Summary
- add `SubscribeScreen` that mocks upgrading a user
- fetch `subscriptionTier` from Firestore in `useUserTier`
- restrict premium emotions in `HomeScreen` and show an upgrade button
- register `SubscribeScreen` in navigation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68428dc3c3a88320b0a8f8cf3ddd054d