### PR TITLE
Add coping tools screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ The `hooks/useUserTier.js` hook reads this value so the app can show premium fea
 ## Emotion Journal
 
 Each time a child interacts with an emotion, a journal entry is saved to Firestore under `users/{uid}/emotions`. Entries include the emotion name, size, temperature and a timestamp. The helper `hooks/useEmotionLogger.js` provides a simple `logEmotionEntry` function used by the app when adding an emotion to the soup.
+
+## Coping Tools
+
+The new `CopingToolsScreen` provides breathing, drawing and journaling tools for kids. Usage of each tool is recorded to Firestore at `users/{uid}/copingLogs`.

--- a/navigation.js
+++ b/navigation.js
@@ -6,6 +6,7 @@ import EmotionDetailScreen from './screens/EmotionDetailScreen';
 import SoupScreen from './screens/SoupScreen';
 import SettingsScreen from './screens/SettingsScreen';
 import ParentDashboardScreen from './screens/ParentDashboardScreen';
+import CopingToolsScreen from './screens/CopingToolsScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -16,6 +17,7 @@ export default function Navigation() {
       <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'Emotion Soup' }} />
       <Stack.Screen name="EmotionDetail" component={EmotionDetailScreen} options={{ title: 'Feeling' }} />
       <Stack.Screen name="Soup" component={SoupScreen} options={{ title: 'Your Soup' }} />
+      <Stack.Screen name="CopingTools" component={CopingToolsScreen} options={{ title: 'Coping Tools' }} />
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: 'Settings' }} />
       <Stack.Screen name="ParentDashboard" component={ParentDashboardScreen} options={{ title: 'Parent Dashboard' }} />
     </Stack.Navigator>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-native-community/slider": "^4.5.7",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
+    "@terrylinla/react-native-sketch-canvas": "^0.8.0",
     "expo": "^49.0.0",
     "firebase": "^10.11.0",
     "lucide-react-native": "^0.513.0",

--- a/screens/CopingToolsScreen.js
+++ b/screens/CopingToolsScreen.js
@@ -1,0 +1,99 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { View, Text, StyleSheet, Button, Animated, TextInput } from 'react-native';
+import { SketchCanvas } from '@terrylinla/react-native-sketch-canvas';
+import { auth, db } from '../firebase';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+
+export default function CopingToolsScreen() {
+  const [tool, setTool] = useState(null);
+  const [journalText, setJournalText] = useState('');
+  const scaleAnim = useRef(new Animated.Value(0)).current;
+  const loopRef = useRef(null);
+
+  const logUsage = async (selected) => {
+    const user = auth.currentUser;
+    if (!user) return;
+    await addDoc(collection(db, 'users', user.uid, 'copingLogs'), {
+      tool: selected,
+      timestamp: serverTimestamp(),
+    });
+  };
+
+  const startBreathing = () => {
+    setTool('breathing');
+    logUsage('breathing');
+  };
+
+  useEffect(() => {
+    if (tool === 'breathing') {
+      loopRef.current = Animated.loop(
+        Animated.sequence([
+          Animated.timing(scaleAnim, { toValue: 1, duration: 3000, useNativeDriver: false }),
+          Animated.timing(scaleAnim, { toValue: 0, duration: 3000, useNativeDriver: false }),
+        ])
+      );
+      loopRef.current.start();
+    } else if (loopRef.current) {
+      loopRef.current.stop();
+      scaleAnim.setValue(0);
+    }
+    return () => {
+      if (loopRef.current) loopRef.current.stop();
+    };
+  }, [tool]);
+
+  const saveJournal = () => {
+    logUsage('journaling');
+    setJournalText('');
+  };
+
+  return (
+    <View style={styles.container}>
+      {!tool && (
+        <>
+          <Button title="Breathing Tool" onPress={startBreathing} />
+          <Button title="Drawing Tool" onPress={() => { setTool('drawing'); logUsage('drawing'); }} />
+          <Button title="Journaling Tool" onPress={() => { setTool('journaling'); logUsage('journaling'); }} />
+        </>
+      )}
+
+      {tool === 'breathing' && (
+        <View style={styles.toolContainer}>
+          <Animated.View
+            style={[styles.circle, { transform: [{ scale: scaleAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 2] }) }] }]}
+          />
+          <Button title="Back" onPress={() => setTool(null)} />
+        </View>
+      )}
+
+      {tool === 'drawing' && (
+        <View style={styles.toolContainer}>
+          <SketchCanvas style={styles.canvas} />
+          <Button title="Back" onPress={() => setTool(null)} />
+        </View>
+      )}
+
+      {tool === 'journaling' && (
+        <View style={styles.toolContainer}>
+          <TextInput
+            style={styles.input}
+            multiline
+            placeholder="Write your thoughts..."
+            value={journalText}
+            onChangeText={setJournalText}
+          />
+          <Button title="Save" onPress={saveJournal} />
+          <Button title="Back" onPress={() => setTool(null)} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+  toolContainer: { flex: 1, alignItems: 'center', justifyContent: 'center', width: '100%' },
+  circle: { width: 100, height: 100, borderRadius: 50, backgroundColor: '#93c5fd', marginBottom: 20 },
+  canvas: { flex: 1, width: '100%', backgroundColor: '#fff' },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 10, width: '100%', minHeight: 150, marginBottom: 10 },
+});

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -27,6 +27,7 @@ export default function HomeScreen({ navigation }) {
         <Text style={styles.title}>How are you feeling?</Text>
         <Button title="Settings" onPress={() => navigation.navigate('Settings')} />
       </View>
+      <Button title="Coping Tools" onPress={() => navigation.navigate('CopingTools')} />
       <Timer />
       <FlatList
         data={EMOTIONS}


### PR DESCRIPTION
## Summary
- add CopingToolsScreen with breathing, drawing and journaling tools
- log coping tool usage in Firestore
- wire screen into navigation and home screen
- document coping tools in README
- add sketch canvas dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68428d92e3088320b8ee92a442cc57c5