### PR TITLE
Add Firebase auth with role-based navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,13 +1,36 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import Navigation from './navigation';
 import { AppProvider } from './context/AppContext';
+import { auth, db } from './firebase';
+import { onAuthStateChanged } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
 
 export default function App() {
+  const [user, setUser] = useState(null);
+  const [role, setRole] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async (u) => {
+      setUser(u);
+      if (u) {
+        const snap = await getDoc(doc(db, 'users', u.uid));
+        if (snap.exists()) setRole(snap.data().role);
+      } else {
+        setRole(null);
+      }
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  if (loading) return null;
+
   return (
     <AppProvider>
       <NavigationContainer>
-        <Navigation />
+        <Navigation user={user} role={role} />
       </NavigationContainer>
     </AppProvider>
   );

--- a/navigation.js
+++ b/navigation.js
@@ -1,18 +1,37 @@
 import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import SplashScreen from './screens/SplashScreen';
+import AgeSelectionScreen from './screens/AgeSelectionScreen';
 import HomeScreen from './screens/HomeScreen';
 import EmotionDetailScreen from './screens/EmotionDetailScreen';
 import SoupScreen from './screens/SoupScreen';
 import SettingsScreen from './screens/SettingsScreen';
 import ParentDashboardScreen from './screens/ParentDashboardScreen';
+import LoginScreen from './screens/LoginScreen';
+import SignupScreen from './screens/SignupScreen';
 
 const Stack = createNativeStackNavigator();
 
-export default function Navigation() {
+export default function Navigation({ user, role }) {
+  if (!user) {
+    return (
+      <Stack.Navigator initialRouteName="Login">
+        <Stack.Screen name="Login" component={LoginScreen} options={{ title: 'Login' }} />
+        <Stack.Screen name="Signup" component={SignupScreen} options={{ title: 'Sign Up' }} />
+      </Stack.Navigator>
+    );
+  }
+
+  if (role === 'Parent') {
+    return (
+      <Stack.Navigator>
+        <Stack.Screen name="ParentDashboard" component={ParentDashboardScreen} options={{ title: 'Parent Dashboard' }} />
+      </Stack.Navigator>
+    );
+  }
+
   return (
-    <Stack.Navigator initialRouteName="Splash">
-      <Stack.Screen name="Splash" component={SplashScreen} options={{ headerShown: false }} />
+    <Stack.Navigator initialRouteName="AgeSelect">
+      <Stack.Screen name="AgeSelect" component={AgeSelectionScreen} options={{ headerShown: false }} />
       <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'Emotion Soup' }} />
       <Stack.Screen name="EmotionDetail" component={EmotionDetailScreen} options={{ title: 'Feeling' }} />
       <Stack.Screen name="Soup" component={SoupScreen} options={{ title: 'Your Soup' }} />

--- a/screens/AgeSelectionScreen.js
+++ b/screens/AgeSelectionScreen.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import { useApp } from '../context/AppContext';
 
-export default function SplashScreen({ navigation }) {
+export default function AgeSelectionScreen({ navigation }) {
   const { setAge } = useApp();
 
   return (

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebase';
+
+export default function LoginScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleLogin = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <Button title="Login" onPress={handleLogin} />
+      <Button title="Sign Up" onPress={() => navigation.navigate('Signup')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 12 },
+  error: { color: 'red', marginBottom: 8 },
+});

--- a/screens/SignupScreen.js
+++ b/screens/SignupScreen.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, Text, StyleSheet } from 'react-native';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { auth, db } from '../firebase';
+import { doc, setDoc } from 'firebase/firestore';
+
+export default function SignupScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('Child');
+  const [error, setError] = useState('');
+
+  const handleSignup = async () => {
+    try {
+      const cred = await createUserWithEmailAndPassword(auth, email, password);
+      await setDoc(doc(db, 'users', cred.user.uid), { email, role });
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+      <Text style={styles.label}>Select Role:</Text>
+      <View style={styles.roles}>
+        <Button title="Parent" onPress={() => setRole('Parent')} color={role==='Parent' ? 'blue' : undefined} />
+        <Button title="Child" onPress={() => setRole('Child')} color={role==='Child' ? 'blue' : undefined} />
+      </View>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <Button title="Sign Up" onPress={handleSignup} />
+      <Button title="Back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 12 },
+  label: { marginBottom: 8 },
+  roles: { flexDirection: 'row', justifyContent: 'space-around', marginBottom: 12 },
+  error: { color: 'red', marginBottom: 8 },
+});


### PR DESCRIPTION
## Summary
- support login and signup screens
- store role during signup and use role to navigate
- fetch role in `App.js` via `onAuthStateChanged`
- show parent or child flows accordingly
- rename SplashScreen to AgeSelectionScreen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68428dd13a9c832092a55815b1fa92a9