### PR TITLE
Add coping tools screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ const data = await getEmotionStats(userId);
 ```
 
 The returned array can be easily adapted for a line chart with the date on the x‑axis and counts per emotion on the y‑axis.
+
+## Coping Tools
+
+The `CopingToolsScreen` offers simple breathing, drawing and journaling activities. Each time a child uses one of these tools a log entry is saved to Firestore under `users/{uid}/copingLogs`.

--- a/hooks/useCopingLogger.js
+++ b/hooks/useCopingLogger.js
@@ -1,0 +1,17 @@
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { auth, db } from '../firebase';
+
+/**
+ * Log a coping tool usage for the current user.
+ *
+ * @param {string} tool One of 'breathing', 'drawing', or 'journal'
+ */
+export default async function logCopingTool(tool) {
+  const user = auth.currentUser;
+  if (!user) return;
+
+  await addDoc(collection(db, 'users', user.uid, 'copingLogs'), {
+    tool,
+    timestamp: serverTimestamp(),
+  });
+}

--- a/navigation.js
+++ b/navigation.js
@@ -7,6 +7,7 @@ import SoupScreen from './screens/SoupScreen';
 import SettingsScreen from './screens/SettingsScreen';
 import ParentDashboardScreen from './screens/ParentDashboardScreen';
 import SubscribeScreen from './screens/SubscribeScreen';
+import CopingToolsScreen from './screens/CopingToolsScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -20,6 +21,7 @@ export default function Navigation() {
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: 'Settings' }} />
       <Stack.Screen name="Subscribe" component={SubscribeScreen} options={{ title: 'Subscribe' }} />
       <Stack.Screen name="ParentDashboard" component={ParentDashboardScreen} options={{ title: 'Parent Dashboard' }} />
+      <Stack.Screen name="CopingTools" component={CopingToolsScreen} options={{ title: 'Coping Tools' }} />
     </Stack.Navigator>
   );
 }

--- a/screens/CopingToolsScreen.js
+++ b/screens/CopingToolsScreen.js
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { View, Text, Button, TextInput, StyleSheet } from 'react-native';
+import logCopingTool from '../hooks/useCopingLogger';
+
+export default function CopingToolsScreen() {
+  const [journalEntry, setJournalEntry] = useState('');
+  const [tool, setTool] = useState(null);
+
+  const startBreathing = async () => {
+    setTool('breathing');
+    await logCopingTool('breathing');
+  };
+
+  const startDrawing = async () => {
+    setTool('drawing');
+    await logCopingTool('drawing');
+  };
+
+  const saveJournal = async () => {
+    await logCopingTool('journal');
+    setJournalEntry('');
+    setTool(null);
+  };
+
+  if (tool === 'breathing') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Breathe in... Breathe out...</Text>
+        <Button title="Done" onPress={() => setTool(null)} />
+      </View>
+    );
+  }
+
+  if (tool === 'drawing') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Imagine a drawing pad here!</Text>
+        <Button title="Done" onPress={() => setTool(null)} />
+      </View>
+    );
+  }
+
+  if (tool === 'journal') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Write about your feelings:</Text>
+        <TextInput
+          value={journalEntry}
+          onChangeText={setJournalEntry}
+          multiline
+          style={styles.input}
+        />
+        <Button title="Save" onPress={saveJournal} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Coping Tools</Text>
+      <Button title="Breathing Exercise" onPress={startBreathing} />
+      <Button title="Drawing Pad" onPress={startDrawing} />
+      <Button title="Journal Entry" onPress={() => setTool('journal')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+  title: { fontSize: 24, marginBottom: 20, textAlign: 'center' },
+  input: { borderWidth: 1, width: '100%', minHeight: 100, marginBottom: 20, padding: 10 },
+});

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -42,6 +42,7 @@ export default function HomeScreen({ navigation }) {
         <Button title="Settings" onPress={() => navigation.navigate('Settings')} />
       </View>
       <Timer />
+      <Button title="Coping Tools" onPress={() => navigation.navigate('CopingTools')} />
       <FlatList
         data={EMOTIONS}
         numColumns={3}


### PR DESCRIPTION
## Summary
- add new `CopingToolsScreen` with breathing, drawing and journaling activities
- log coping tool usage with `useCopingLogger`
- expose CopingTools screen through navigation and Home screen
- document Coping Tools in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68428f65f4148320977cac0d815d29c7