### PR TITLE
Add coping tools screen

### DIFF
--- a/navigation.js
+++ b/navigation.js
@@ -7,6 +7,7 @@ import SoupScreen from './screens/SoupScreen';
 import SettingsScreen from './screens/SettingsScreen';
 import ParentDashboardScreen from './screens/ParentDashboardScreen';
 import SubscribeScreen from './screens/SubscribeScreen';
+import CopingToolsScreen from './screens/CopingToolsScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -18,6 +19,7 @@ export default function Navigation() {
       <Stack.Screen name="EmotionDetail" component={EmotionDetailScreen} options={{ title: 'Feeling' }} />
       <Stack.Screen name="Soup" component={SoupScreen} options={{ title: 'Your Soup' }} />
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: 'Settings' }} />
+      <Stack.Screen name="CopingTools" component={CopingToolsScreen} options={{ title: 'Coping Tools' }} />
       <Stack.Screen name="Subscribe" component={SubscribeScreen} options={{ title: 'Subscribe' }} />
       <Stack.Screen name="ParentDashboard" component={ParentDashboardScreen} options={{ title: 'Parent Dashboard' }} />
     </Stack.Navigator>

--- a/screens/CopingToolsScreen.js
+++ b/screens/CopingToolsScreen.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+
+export default function CopingToolsScreen() {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Coping Tools</Text>
+      <View style={styles.tool}>
+        <Text style={styles.toolTitle}>1. Take Deep Breaths</Text>
+        <Text style={styles.toolDesc}>Breathe in slowly, hold it, then breathe out to calm down.</Text>
+      </View>
+      <View style={styles.tool}>
+        <Text style={styles.toolTitle}>2. Journal</Text>
+        <Text style={styles.toolDesc}>Write or draw how you feel to let the feelings out.</Text>
+      </View>
+      <View style={styles.tool}>
+        <Text style={styles.toolTitle}>3. Talk to a Friend</Text>
+        <Text style={styles.toolDesc}>Share your feelings with someone you trust.</Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 20 },
+  title: { fontSize: 24, marginBottom: 20, textAlign: 'center' },
+  tool: { marginBottom: 20 },
+  toolTitle: { fontSize: 18, fontWeight: 'bold' },
+  toolDesc: { marginTop: 4 },
+});

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -58,6 +58,10 @@ export default function HomeScreen({ navigation }) {
           </View>
         )}
       />
+      <Button
+        title="Coping Tools"
+        onPress={() => navigation.navigate('CopingTools')}
+      />
       {tier !== 'premium' && (
         <Button
           title="Upgrade to Premium"


### PR DESCRIPTION
## Summary
- implement `CopingToolsScreen` with three basic strategies
- hook up the screen in the navigation stack
- add button on the home screen to access coping tools

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68428fa33f1c8320abe39bfe4be5bce8