### PR TITLE
Fix dependency version for chart kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "nativewind": "^4.1.23",
         "react": "18.x",
         "react-native": "0.72.x",
+        "react-native-chart-kit": "^6.12.0",
         "react-native-paper": "^5.0.0",
         "zustand": "^5.0.5"
       },
@@ -12644,6 +12645,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/paths-js": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/paths-js/-/paths-js-0.4.11.tgz",
+      "integrity": "sha512-3mqcLomDBXOo7Fo+UlaenG6f71bk1ZezPQy2JCmYHy2W2k5VKpP+Jbin9H0bjXynelTbglCqdFhSEkeIkKTYUA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.11.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -12866,6 +12876,12 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -13375,6 +13391,22 @@
       },
       "peerDependencies": {
         "react": "18.2.0"
+      }
+    },
+    "node_modules/react-native-chart-kit": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-6.12.0.tgz",
+      "integrity": "sha512-nZLGyCFzZ7zmX0KjYeeSV1HKuPhl1wOMlTAqa0JhlyW62qV/1ZPXHgT8o9s8mkFaGxdqbspOeuaa6I9jUQDgnA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.13",
+        "paths-js": "^0.4.10",
+        "point-in-polygon": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": "> 16.7.0",
+        "react-native": ">= 0.50.0",
+        "react-native-svg": "> 6.4.1"
       }
     },
     "node_modules/react-native-css-interop": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-native": "0.72.x",
     "react-native-paper": "^5.0.0",
     "zustand": "^5.0.5",
-    "react-native-chart-kit": "^6.14.1"
+    "react-native-chart-kit": "^6.12.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.6",


### PR DESCRIPTION
## Summary
- update react-native-chart-kit version to valid release

## Testing
- `npm install --package-lock-only` *(fails: no network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6844f30a6eec8320bc8684036034cff2