### PR TITLE
Fix Expo build config

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "Emotion Soup",
+    "slug": "emotion-soup",
+    "version": "1.2.0",
+    "sdkVersion": "49.0.0",
+    "platforms": ["ios", "android"],
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "light"
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,6 @@
-module.exports = {
-  presets: ['@babel/preset-env'],
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
 };


### PR DESCRIPTION
## Summary
- use `babel-preset-expo` so Metro can compile the app
- add an `app.json` with basic Expo config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845003610708320a0f42596314bee44