### PR TITLE
Fix age gate logic for mode access

### DIFF
--- a/lib/attempt_mode_switch.js
+++ b/lib/attempt_mode_switch.js
@@ -9,7 +9,8 @@ export default function useAttemptModeSwitch() {
   const { tier } = useUserTier();
 
   return (mode) => {
-    if (age && age < 6 && mode !== 'soup') {
+    const ageNumber = parseInt(age, 10);
+    if (!isNaN(ageNumber) && ageNumber < 6 && mode !== 'soup') {
       Alert.alert('Locked', 'This mode is for ages 6 and up.');
     } else if (tier !== 'premium' && mode !== 'soup') {
       Alert.alert('Upgrade', 'Subscribe to access this mode.');


### PR DESCRIPTION
## Summary
- parse age string when checking mode access gate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881e4f16e5c8320af34fee36d574e06