### PR TITLE
Add Firebase error handling

### DIFF
--- a/hooks/useCopingLogger.js
+++ b/hooks/useCopingLogger.js
@@ -1,5 +1,6 @@
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '../firebase';
+import { Alert } from 'react-native';
 
 /**
  * Log a coping tool usage for the current user.
@@ -8,10 +9,18 @@ import { auth, db } from '../firebase';
  */
 export default async function logCopingTool(tool) {
   const user = auth.currentUser;
-  if (!user) return;
+  if (!user) {
+    Alert.alert('Not Signed In', 'Please log in to record coping tools.');
+    return;
+  }
 
-  await addDoc(collection(db, 'users', user.uid, 'copingLogs'), {
-    tool,
-    timestamp: serverTimestamp(),
-  });
+  try {
+    await addDoc(collection(db, 'users', user.uid, 'copingLogs'), {
+      tool,
+      timestamp: serverTimestamp(),
+    });
+  } catch (err) {
+    console.error('Failed to log coping tool:', err);
+    Alert.alert('Error', 'Could not log this action. Please try again later.');
+  }
 }

--- a/hooks/useEmotionLogger.js
+++ b/hooks/useEmotionLogger.js
@@ -1,5 +1,6 @@
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '../firebase';
+import { Alert } from 'react-native';
 
 export default async function logEmotionEntry({
   emotion,
@@ -8,13 +9,21 @@ export default async function logEmotionEntry({
   helpRequested = false,
 }) {
   const user = auth.currentUser;
-  if (!user) return;
+  if (!user) {
+    Alert.alert('Not Signed In', 'Please log in to log emotions.');
+    return;
+  }
 
-  await addDoc(collection(db, 'users', user.uid, 'emotions'), {
-    emotion,
-    size,
-    temperature,
-    helpRequested,
-    timestamp: serverTimestamp(),
-  });
+  try {
+    await addDoc(collection(db, 'users', user.uid, 'emotions'), {
+      emotion,
+      size,
+      temperature,
+      helpRequested,
+      timestamp: serverTimestamp(),
+    });
+  } catch (err) {
+    console.error('Failed to log emotion entry:', err);
+    Alert.alert('Error', 'Could not save your entry. Please try again later.');
+  }
 }

--- a/hooks/useUserTier.js
+++ b/hooks/useUserTier.js
@@ -14,13 +14,21 @@ export default function useUserTier() {
     }
 
     const fetchTier = async () => {
-      const docRef = doc(db, 'users', uid);
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        const data = docSnap.data();
-        setTier(data.subscriptionTier || data.tier || 'free');
+      try {
+        const docRef = doc(db, 'users', uid);
+        const docSnap = await getDoc(docRef);
+        if (docSnap.exists()) {
+          const data = docSnap.data();
+          setTier(data.subscriptionTier || data.tier || 'free');
+        } else {
+          setTier('free');
+        }
+      } catch (err) {
+        console.error('Failed to fetch user tier:', err);
+        setTier('free');
+      } finally {
+        setLoading(false);
       }
-      setLoading(false);
     };
 
     fetchTier();

--- a/screens/ParentDashboardScreen.js
+++ b/screens/ParentDashboardScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ScrollView, StyleSheet, View, Dimensions } from 'react-native';
+import { ScrollView, StyleSheet, View, Dimensions, Alert } from 'react-native';
 import { Appbar, Card, Text, List, Divider } from 'react-native-paper';
 import { db } from '../firebase';
 import {
@@ -34,53 +34,61 @@ export default function ParentDashboardScreen({ navigation, userId }) {
     if (!uid) return;
 
     const fetchData = async () => {
-      const emotionsRef = collection(db, 'users', uid, 'emotions');
-      const recentQuery = query(
-        emotionsRef,
-        orderBy('timestamp', 'desc'),
-        limit(10)
-      );
-      const recentSnap = await getDocs(recentQuery);
-      const recent = recentSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
-      setRecentEmotions(recent);
+      try {
+        const emotionsRef = collection(db, 'users', uid, 'emotions');
+        const recentQuery = query(
+          emotionsRef,
+          orderBy('timestamp', 'desc'),
+          limit(10)
+        );
+        const recentSnap = await getDocs(recentQuery);
+        const recent = recentSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setRecentEmotions(recent);
 
-      const start = new Date();
-      start.setHours(0, 0, 0, 0);
-      start.setDate(start.getDate() - 6);
-      const trendQuery = query(
-        emotionsRef,
-        where('timestamp', '>=', start),
-        orderBy('timestamp', 'asc')
-      );
-      const trendSnap = await getDocs(trendQuery);
-      const counts = {};
-      trendSnap.forEach((doc) => {
-        const dateStr = doc
-          .data()
-          .timestamp.toDate()
-          .toISOString()
-          .slice(0, 10);
-        counts[dateStr] = (counts[dateStr] || 0) + 1;
-      });
-      const labels = [];
-      const data = [];
-      for (let i = 6; i >= 0; i--) {
-        const d = new Date();
-        d.setDate(d.getDate() - i);
-        const key = d.toISOString().slice(0, 10);
-        labels.push(d.toISOString().slice(5, 10));
-        data.push(counts[key] || 0);
+        const start = new Date();
+        start.setHours(0, 0, 0, 0);
+        start.setDate(start.getDate() - 6);
+        const trendQuery = query(
+          emotionsRef,
+          where('timestamp', '>=', start),
+          orderBy('timestamp', 'asc')
+        );
+        const trendSnap = await getDocs(trendQuery);
+        const counts = {};
+        trendSnap.forEach((doc) => {
+          const dateStr = doc
+            .data()
+            .timestamp.toDate()
+            .toISOString()
+            .slice(0, 10);
+          counts[dateStr] = (counts[dateStr] || 0) + 1;
+        });
+        const labels = [];
+        const data = [];
+        for (let i = 6; i >= 0; i--) {
+          const d = new Date();
+          d.setDate(d.getDate() - i);
+          const key = d.toISOString().slice(0, 10);
+          labels.push(d.toISOString().slice(5, 10));
+          data.push(counts[key] || 0);
+        }
+        setTrendData({ labels, data });
+
+        const alertQuery = query(
+          collection(db, 'users', uid, 'alerts'),
+          where('flagged', '==', true),
+          orderBy('timestamp', 'desc')
+        );
+        const alertSnap = await getDocs(alertQuery);
+        const alertList = alertSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setAlerts(alertList);
+      } catch (err) {
+        console.error('Failed to load dashboard data:', err);
+        Alert.alert(
+          'Error',
+          'Unable to load dashboard information. Please check your connection and try again.'
+        );
       }
-      setTrendData({ labels, data });
-
-      const alertQuery = query(
-        collection(db, 'users', uid, 'alerts'),
-        where('flagged', '==', true),
-        orderBy('timestamp', 'desc')
-      );
-      const alertSnap = await getDocs(alertQuery);
-      const alertList = alertSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
-      setAlerts(alertList);
     };
 
     fetchData();

--- a/screens/SubscribeScreen.js
+++ b/screens/SubscribeScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, Text, Button, StyleSheet, Alert } from 'react-native';
 import { auth, db } from '../firebase';
 import { doc, setDoc } from 'firebase/firestore';
 
@@ -8,13 +8,24 @@ export default function SubscribeScreen() {
 
   const upgrade = async () => {
     const uid = auth.currentUser?.uid;
-    if (!uid) return;
-    await setDoc(
-      doc(db, 'users', uid),
-      { subscriptionTier: 'premium' },
-      { merge: true }
-    );
-    setThanks(true);
+    if (!uid) {
+      Alert.alert('Not Signed In', 'Please log in or create an account to upgrade.');
+      return;
+    }
+    try {
+      await setDoc(
+        doc(db, 'users', uid),
+        { subscriptionTier: 'premium' },
+        { merge: true }
+      );
+      setThanks(true);
+    } catch (err) {
+      console.error('Upgrade failed:', err);
+      Alert.alert(
+        'Upgrade Failed',
+        'Could not upgrade at this time. Please check your connection and try again.'
+      );
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- show alerts when upgrade fails or user not signed in
- handle Firestore errors in `useUserTier`
- notify users if logging actions fails
- guard against failures in Parent Dashboard queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881e5d7a3c4832094df92705a040046