### PR TITLE
Connect Soup Buddy to emotion selections

### DIFF
--- a/hooks/useSoupSaver.js
+++ b/hooks/useSoupSaver.js
@@ -1,0 +1,22 @@
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { auth, db } from '../firebase';
+import { Alert } from 'react-native';
+
+export default async function saveSoup(name, emotions) {
+  const user = auth.currentUser;
+  if (!user) {
+    Alert.alert('Not Signed In', 'Please log in to save your soup.');
+    return;
+  }
+  try {
+    await addDoc(collection(db, 'users', user.uid, 'soups'), {
+      name,
+      emotions,
+      timestamp: serverTimestamp(),
+    });
+    Alert.alert('Saved', 'Your soup has been saved!');
+  } catch (err) {
+    console.error('Failed to save soup:', err);
+    Alert.alert('Error', 'Could not save your soup. Please try again later.');
+  }
+}

--- a/screens/SoupScreen.js
+++ b/screens/SoupScreen.js
@@ -1,10 +1,42 @@
-import React from 'react';
-import { View, Text, FlatList, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  TextInput,
+  Button,
+  ActivityIndicator,
+} from 'react-native';
+import * as Speech from 'expo-speech';
 import { useApp } from '../context/AppContext';
 import PuffBall from '../components/PuffBall';
+import saveSoup from '../hooks/useSoupSaver';
+import { generateSoupBuddyResponse } from '../utils/aiBehavior';
 
 export default function SoupScreen() {
-  const { selectedEmotions } = useApp();
+  const { selectedEmotions, age } = useApp();
+  const [name, setName] = useState('');
+  const [buddyText, setBuddyText] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const askBuddy = async () => {
+    setLoading(true);
+    try {
+      const text = generateSoupBuddyResponse(selectedEmotions, age || '8-12');
+      setBuddyText(text);
+      Speech.speak(text);
+    } catch (err) {
+      setBuddyText("I'm not sure what to say, but let's take a deep breath together.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    await saveSoup(name || 'My Soup', selectedEmotions);
+    setName('');
+  };
 
   return (
     <View style={styles.container}>
@@ -19,6 +51,20 @@ export default function SoupScreen() {
           </View>
         )}
       />
+      <TextInput
+        placeholder="Name your soup"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      <Button title="Ask Soup Buddy" onPress={askBuddy} />
+      {loading && <ActivityIndicator style={{ marginVertical: 10 }} />}
+      {buddyText !== '' && (
+        <View style={styles.bubble}>
+          <Text style={styles.bubbleText}>{buddyText}</Text>
+        </View>
+      )}
+      <Button title="Save Soup" onPress={handleSave} />
     </View>
   );
 }
@@ -27,4 +73,22 @@ const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', paddingTop: 40 },
   title: { fontSize: 20, marginBottom: 20 },
   item: { flexDirection: 'row', alignItems: 'center', marginVertical: 5 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginVertical: 10,
+    width: '90%',
+    borderRadius: 6,
+  },
+  bubble: {
+    backgroundColor: '#fff',
+    padding: 12,
+    borderRadius: 12,
+    marginVertical: 10,
+    width: '90%',
+  },
+  bubbleText: {
+    fontSize: 16,
+  },
 });

--- a/utils/__tests__/summarizeSoup.test.js
+++ b/utils/__tests__/summarizeSoup.test.js
@@ -1,0 +1,17 @@
+const { summarizeSoup } = require('../summarizeSoup');
+
+test('summarizeSoup computes breakdown and dominant', () => {
+  const data = [
+    { id: 'anger', color: 'red', size: 80 },
+    { id: 'anger', color: 'red', size: 60 },
+    { id: 'sadness', color: 'blue', size: 40 }
+  ];
+  const result = summarizeSoup(data);
+  expect(result).toEqual({
+    breakdown: [
+      { emotion: 'anger', color: 'red', count: 2, avgSize: 70 },
+      { emotion: 'sadness', color: 'blue', count: 1, avgSize: 40 }
+    ],
+    dominant: { emotion: 'anger', color: 'red', count: 2, avgSize: 70 }
+  });
+});

--- a/utils/aiBehavior.js
+++ b/utils/aiBehavior.js
@@ -18,3 +18,33 @@ export function suggestActivities(emotion) {
   // Placeholder suggestions based on emotion
   return ['deep breath', 'draw', 'talk', 'move'];
 }
+
+import { summarizeSoup } from './summarizeSoup';
+
+/**
+ * Generate a child-friendly response based on the selected emotion puff balls.
+ * The response reflects dominant emotions and offers a gentle regulation idea.
+ *
+ * @param {Array} emotions Array of emotion objects
+ * @param {string} age Age range string, e.g. '4-7'
+ * @returns {string} Friendly guidance text
+ */
+export function generateSoupBuddyResponse(emotions = [], age = '8-12') {
+  const { breakdown } = summarizeSoup(emotions);
+  if (!breakdown.length) {
+    return "I don't see any feelings in the bowl yet. Pick some puff balls first.";
+  }
+
+  const tone = getToneByAge(age);
+  const lines = breakdown.map((b) => {
+    let intensity;
+    if (b.count >= 7) intensity = 'so much';
+    else if (b.count >= 4) intensity = 'a lot of';
+    else if (b.count >= 2) intensity = 'some';
+    else intensity = 'a little';
+    const suggestion = suggestActivities(b.emotion)[0];
+    return `${intensity} ${b.emotion}. Maybe try ${suggestion}.`;
+  });
+
+  return `In my ${tone} voice: I see ${lines.join(' ')} You are doing great!`;
+}

--- a/utils/summarizeSoup.js
+++ b/utils/summarizeSoup.js
@@ -1,0 +1,23 @@
+export function summarizeSoup(emotions = []) {
+  const grouped = {};
+  emotions.forEach((e) => {
+    const id = e.id || e.emotion;
+    if (!id) return;
+    if (!grouped[id]) grouped[id] = { count: 0, color: e.color, totalSize: 0 };
+    grouped[id].count += 1;
+    if (e.size) grouped[id].totalSize += e.size;
+  });
+
+  const breakdown = [];
+  let dominant = null;
+  Object.entries(grouped).forEach(([emotion, info]) => {
+    const avgSize = info.count ? Math.round(info.totalSize / info.count) : 0;
+    const item = { emotion, color: info.color, count: info.count, avgSize };
+    breakdown.push(item);
+    if (!dominant || info.count > dominant.count) {
+      dominant = { emotion, color: info.color, count: info.count, avgSize };
+    }
+  });
+
+  return { breakdown, dominant };
+}


### PR DESCRIPTION
## Summary
- create summary helper for the soup
- expand AI behavior with generateSoupBuddyResponse
- add hook to save soups
- integrate Soup Buddy dialog and audio into SoupScreen
- test new summarizeSoup helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68846be7a2108320b4471439f766dfb2