### PR TITLE
Add voice narration using text-to-speech context

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,17 +5,20 @@ import { enableScreens } from 'react-native-screens';
 import Navigation from './navigation';
 import { AppProvider } from './context/AppContext';
 import { ModeProvider } from './lib/mode_controller';
+import { TTSProvider } from './context/TTSContext';
 
 enableScreens();
 
 export default function App() {
   return (
     <AppProvider>
-      <ModeProvider>
-        <NavigationContainer>
-          <Navigation />
-        </NavigationContainer>
-      </ModeProvider>
+      <TTSProvider>
+        <ModeProvider>
+          <NavigationContainer>
+            <Navigation />
+          </NavigationContainer>
+        </ModeProvider>
+      </TTSProvider>
     </AppProvider>
   );
 }

--- a/context/TTSContext.js
+++ b/context/TTSContext.js
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as Speech from 'expo-speech';
+
+const TTSContext = createContext();
+
+export function TTSProvider({ children }) {
+  const [voice, setVoice] = useState(null);
+
+  useEffect(() => {
+    async function init() {
+      try {
+        const voices = await Speech.getAvailableVoicesAsync();
+        const childVoice = voices.find((v) => /child|kid/i.test(v.name));
+        setVoice(childVoice ? childVoice.identifier : voices[0]?.identifier);
+      } catch (e) {
+        console.log('TTS init error', e);
+      }
+    }
+    init();
+  }, []);
+
+  const speak = (text) => {
+    if (!text) return;
+    Speech.stop();
+    Speech.speak(text, {
+      voice,
+      rate: 0.8,
+      pitch: 1.1,
+    });
+  };
+
+  return (
+    <TTSContext.Provider value={{ speak }}>
+      {children}
+    </TTSContext.Provider>
+  );
+}
+
+export function useTTS() {
+  return useContext(TTSContext);
+}

--- a/screens/EmotionDetailScreen.js
+++ b/screens/EmotionDetailScreen.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Button, ActivityIndicator } from 'react-native';
-import * as Speech from 'expo-speech';
+import { useTTS } from '../context/TTSContext';
 import EmotionPuffBall from '../components/EmotionPuffBall';
 import EmotionSliders from '../components/EmotionSliders';
 import { useApp } from '../context/AppContext';
@@ -16,8 +16,10 @@ export default function EmotionDetailScreen({ route, navigation }) {
   const [helpRequested, setHelpRequested] = useState(false);
   const { tier, loading } = useUserTier();
 
+  const { speak } = useTTS();
+
   const speakPrompt = () => {
-    Speech.speak(`You chose ${emotion.id}. What does it feel like in your body?`);
+    speak(`You chose ${emotion.id}. What does it feel like in your body?`);
   };
 
   const addToSoup = async () => {

--- a/screens/SoupScreen.js
+++ b/screens/SoupScreen.js
@@ -8,7 +8,9 @@ import {
   Button,
   ActivityIndicator,
 } from 'react-native';
-import * as Speech from 'expo-speech';
+import { Pressable } from 'react-native';
+import { useTTS } from '../context/TTSContext';
+import Volume2 from 'lucide-react-native/dist/esm/icons/volume-2';
 import { useApp } from '../context/AppContext';
 import PuffBall from '../components/PuffBall';
 import saveSoup from '../hooks/useSoupSaver';
@@ -16,6 +18,7 @@ import { generateSoupBuddyResponse } from '../utils/aiBehavior';
 
 export default function SoupScreen() {
   const { selectedEmotions, age } = useApp();
+  const { speak } = useTTS();
   const [name, setName] = useState('');
   const [buddyText, setBuddyText] = useState('');
   const [loading, setLoading] = useState(false);
@@ -25,7 +28,7 @@ export default function SoupScreen() {
     try {
       const text = generateSoupBuddyResponse(selectedEmotions, age || '8-12');
       setBuddyText(text);
-      Speech.speak(text);
+      speak(text);
     } catch (err) {
       setBuddyText("I'm not sure what to say, but let's take a deep breath together.");
     } finally {
@@ -62,6 +65,9 @@ export default function SoupScreen() {
       {buddyText !== '' && (
         <View style={styles.bubble}>
           <Text style={styles.bubbleText}>{buddyText}</Text>
+          <Pressable onPress={() => speak(buddyText)} style={styles.icon}>
+            <Volume2 size={24} color="#555" />
+          </Pressable>
         </View>
       )}
       <Button title="Save Soup" onPress={handleSave} />
@@ -90,5 +96,10 @@ const styles = StyleSheet.create({
   },
   bubbleText: {
     fontSize: 16,
+  },
+  icon: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
   },
 });


### PR DESCRIPTION
## Summary
- add `TTSContext` to manage text‑to‑speech settings
- initialize a child‑friendly voice when the app starts
- speak all prompts with a gentle rate and pitch
- add replay speaker icon to Soup Buddy responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68846dbbe4f08320ab9e555653c1780a