### PR TITLE
chore: update Android config for SDK 34 and Crashlytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules/
 .DS_Store
 ios/*
 !ios/Podfile
-android/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,29 @@
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion 34
+
+    defaultConfig {
+        applicationId "com.emotionsoup.app"
+        minSdkVersion 23
+        targetSdkVersion 34
+        versionCode 10001
+        versionName "0.9.0-beta1"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}
+
+apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,7 @@
+-keepattributes *Annotation*
+-keep class com.google.firebase.** { *; }
+-dontwarn com.google.firebase.**
+# -keep class com.google.gson.** { *; }
+# -keepclassmembers class * {
+#     @com.google.gson.annotations.SerializedName <fields>;
+# }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.emotionsoup.app">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
+    <application
+        android:usesCleartextTraffic="false">
+    </application>
+</manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,18 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.google.gms:google-services:4.4.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.2'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}


### PR DESCRIPTION
## Summary
- target SDK 34 with min SDK 23 and version 0.9.0-beta1
- enable R8 shrink and add Crashlytics/Google services plugins
- add modern media permissions and Firebase ProGuard keep rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c07e7a0c8320b27d35a3c064d2dd