### PR TITLE
Add iOS Crashlytics configuration and privacy usage strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules/
 .DS_Store
 ios/*
 !ios/Podfile
+!ios/Runner/
+!ios/Runner/Info.plist
+!ios/Runner/AppDelegate.swift

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,0 +1,15 @@
+import UIKit
+import Flutter
+import FirebaseCore
+import FirebaseCrashlytics
+
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate {
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    FirebaseApp.configure()
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.clearsky.photo</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Emotion Soup</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>NSCameraUsageDescription</key>
+  <string>Allow Emotion Soup to access your camera to take photos.</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>Allow Emotion Soup to access your photo library to choose photos.</string>
+  <key>NSPhotoLibraryAddUsageDescription</key>
+  <string>Allow Emotion Soup to save photos to your library.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add Info.plist with required camera and photo library usage descriptions
- Configure Firebase Crashlytics in AppDelegate
- Adjust .gitignore to include iOS runner files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c24bc83c8320b1a87c0bca051cba