### PR TITLE
chore: add beta prep scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ ios/*
 !ios/Runner/
 !ios/Runner/Info.plist
 !ios/Runner/AppDelegate.swift
+
+build/

--- a/README.md
+++ b/README.md
@@ -83,3 +83,21 @@ The returned array can be easily adapted for a line chart with the date on the x
 ## Coping Tools
 
 The `CopingToolsScreen` offers simple breathing, drawing and journaling activities. Each time a child uses one of these tools a log entry is saved to Firestore under `users/{uid}/copingLogs`.
+
+### Beta Prep (local)
+
+**macOS (bash/zsh):**
+```bash
+chmod +x scripts/beta_prep_flutter.sh
+APP_VERSION=0.9.0-beta1 BUILD_NUMBER=10001 scripts/beta_prep_flutter.sh
+```
+
+**Windows (PowerShell):**
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass
+$env:APP_VERSION="0.9.0-beta1"; $env:BUILD_NUMBER="10001"; ./scripts/beta_prep_flutter.ps1
+```
+
+Artifacts:
+- Android AAB: `build/app/outputs/bundle/release/*.aab`
+- iOS IPA: `build/ios/ipa/*.ipa`

--- a/scripts/beta_prep_flutter.ps1
+++ b/scripts/beta_prep_flutter.ps1
@@ -1,0 +1,48 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$APP_VERSION = $env:APP_VERSION
+if (-not $APP_VERSION) { $APP_VERSION = "0.9.0-beta1" }
+
+$BUILD_NUMBER = $env:BUILD_NUMBER
+if (-not $BUILD_NUMBER) { $BUILD_NUMBER = "10001" }
+
+Write-Host "==> Flutter version"
+flutter --version
+
+Write-Host "==> [1/7] Clean"
+flutter clean
+
+Write-Host "==> [2/7] Pub get"
+flutter pub get
+
+Write-Host "==> [3/7] Analyze"
+flutter analyze
+
+Write-Host "==> [4/7] Test"
+flutter test
+
+Write-Host "==> [5/7] Android AAB (release)"
+flutter build appbundle --release `
+  --build-name=$APP_VERSION `
+  --build-number=$BUILD_NUMBER `
+  --split-debug-info=build/symbols/android
+
+Write-Host "==> [6/7] iOS IPA (unsigned)"
+if ($IsMacOS -or $env:OS -eq "Darwin") {
+  Push-Location ios
+  pod install --repo-update
+  Pop-Location
+
+  flutter build ipa --release --no-codesign `
+    --build-name=$APP_VERSION `
+    --build-number=$BUILD_NUMBER `
+    --split-debug-info=build/symbols/ios
+} else {
+  Write-Host "Skipping iOS build: requires macOS + Xcode."
+}
+
+Write-Host "==> [7/7] Done"
+Write-Host "Artifacts:"
+Write-Host "  Android AAB: build/app/outputs/bundle/release/*.aab"
+Write-Host "  iOS IPA:     build/ios/ipa/*.ipa (macOS only)"

--- a/scripts/beta_prep_flutter.sh
+++ b/scripts/beta_prep_flutter.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_VERSION="${APP_VERSION:-0.9.0-beta1}"
+BUILD_NUMBER="${BUILD_NUMBER:-10001}"
+
+echo "==> Flutter version"
+flutter --version
+
+echo "==> [1/7] Clean"
+flutter clean
+
+echo "==> [2/7] Pub get"
+flutter pub get
+
+echo "==> [3/7] Analyze"
+flutter analyze
+
+echo "==> [4/7] Test"
+flutter test
+
+echo "==> [5/7] Android AAB (release)"
+flutter build appbundle --release \
+  --build-name="$APP_VERSION" \
+  --build-number="$BUILD_NUMBER" \
+  --split-debug-info=build/symbols/android
+
+echo "==> [6/7] iOS IPA (unsigned)"
+pushd ios >/dev/null
+pod install --repo-update
+popd >/dev/null
+
+flutter build ipa --release --no-codesign \
+  --build-name="$APP_VERSION" \
+  --build-number="$BUILD_NUMBER" \
+  --split-debug-info=build/symbols/ios
+
+echo "==> [7/7] Done"
+echo "Artifacts:"
+echo "  Android AAB: build/app/outputs/bundle/release/*.aab"
+echo "  iOS IPA:     build/ios/ipa/*.ipa"


### PR DESCRIPTION
## Summary
- add macOS and Windows scripts to clean, analyze, test and build Flutter app
- document local beta prep workflow and artifact locations
- ignore generated build artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d43b5afc8320926f6a5dc5b35823